### PR TITLE
✨ : k8s executor

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           java-version: 17
       - name: Run Maven tests
-        run: mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
+        run: mvn --batch-mode org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 17
+      - name: Start Minikube
+        run: minikube start
+      - name: Create test namespace
+        run: kubectl create ns gaia-runner
       - name: Run Maven tests
         run: mvn --batch-mode org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
         with:
           # fetching all history (to help sonar computing PRs)
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Run Maven tests
         run: mvn org.jacoco:jacoco-maven-plugin:prepare-agent verify org.jacoco:jacoco-maven-plugin:report sonar:sonar
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3-openjdk-15 as BUILD
+FROM maven:3-openjdk-17 as BUILD
 
 COPY . /usr/src/app
 RUN mvn --batch-mode -DskipTests -f /usr/src/app/pom.xml clean package
 
-FROM openjdk:15-jdk
+FROM openjdk:17-jdk
 COPY --from=BUILD /usr/src/app/target/*.jar /opt/target/runner.jar
 WORKDIR /opt/target
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.6.3</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
 
     <properties>
         <docker-java.version>3.2.7</docker-java.version>
-        <jacoco.version>0.8.6</jacoco.version>
-        <java.version>11</java.version>
-        <kotlin.version>1.4.21</kotlin.version>
+        <jacoco.version>0.8.7</jacoco.version>
+        <java.version>17</java.version>
+        <kotlin.version>1.6.10</kotlin.version>
 
         <sonar.projectKey>gaia-app:runner</sonar.projectKey>
         <sonar.organization>gaia-app</sonar.organization>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
         <sonar.projectKey>gaia-app:runner</sonar.projectKey>
         <sonar.organization>gaia-app</sonar.organization>
         <sonar.host.url>https://sonarcloud.io/</sonar.host.url>
+        <kubernetes-client-java.version>14.0.0</kubernetes-client-java.version>
+        <testcontainers.version>1.16.3</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -82,6 +84,19 @@
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-transport-okhttp</artifactId>
             <version>${docker-java.version}</version>
+        </dependency>
+
+        <!-- kubernetes client -->
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java</artifactId>
+            <version>${kubernetes-client-java.version}</version>
+        </dependency>
+        <!-- kubernetes fluent API -->
+        <dependency>
+            <groupId>io.kubernetes</groupId>
+            <artifactId>client-java-extended</artifactId>
+            <version>${kubernetes-client-java.version}</version>
         </dependency>
 
         <!-- jackson support for kotlin -->

--- a/src/main/java/io/gaia_app/runner/Executor.java
+++ b/src/main/java/io/gaia_app/runner/Executor.java
@@ -1,0 +1,20 @@
+package io.gaia_app.runner;
+
+import java.util.List;
+
+/**
+ * Interface of the executors.
+ * This interface should be implemented for all Runner executors (docker, k8s, ...)
+ */
+public interface Executor {
+
+    /**
+     * Run a Gaia job step.
+     * @param image the docker image to use
+     * @param logger the logger to use. All the logs will be send to Gaia.
+     * @param script the script to executre
+     * @param jobEnv env vars to use when executing the script
+     * @return the result code of the execution, 0 if everything went well, !0 otherwise
+     */
+    int executeJobStep(String image, StepLogger logger, String script, List<String> jobEnv);
+}

--- a/src/main/java/io/gaia_app/runner/Executor.java
+++ b/src/main/java/io/gaia_app/runner/Executor.java
@@ -1,7 +1,5 @@
 package io.gaia_app.runner;
 
-import java.util.List;
-
 /**
  * Interface of the executors.
  * This interface should be implemented for all Runner executors (docker, k8s, ...)
@@ -10,11 +8,9 @@ public interface Executor {
 
     /**
      * Run a Gaia job step.
-     * @param image the docker image to use
+     * @param runnerStep the step to run. It contains the script and the env vars to use.
      * @param logger the logger to use. All the logs will be send to Gaia.
-     * @param script the script to executre
-     * @param jobEnv env vars to use when executing the script
      * @return the result code of the execution, 0 if everything went well, !0 otherwise
      */
-    int executeJobStep(String image, StepLogger logger, String script, List<String> jobEnv);
+    int executeJobStep(RunnerStep runnerStep, StepLogger logger);
 }

--- a/src/main/java/io/gaia_app/runner/ExecutorType.java
+++ b/src/main/java/io/gaia_app/runner/ExecutorType.java
@@ -1,5 +1,5 @@
 package io.gaia_app.runner;
 
 public enum ExecutorType {
-    DOCKER
+    DOCKER, K8S
 }

--- a/src/main/java/io/gaia_app/runner/ExecutorType.java
+++ b/src/main/java/io/gaia_app/runner/ExecutorType.java
@@ -1,0 +1,5 @@
+package io.gaia_app.runner;
+
+public enum ExecutorType {
+    DOCKER
+}

--- a/src/main/java/io/gaia_app/runner/StepRunner.java
+++ b/src/main/java/io/gaia_app/runner/StepRunner.java
@@ -1,6 +1,6 @@
 package io.gaia_app.runner;
 
-import io.gaia_app.runner.docker.DockerRunner;
+import io.gaia_app.runner.docker.DockerExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,15 +15,15 @@ public class StepRunner {
 
     private static final String API_RUNNER_STEPS = "/api/runner/steps/";
 
-    private final DockerRunner dockerRunner;
+    private final DockerExecutor dockerExecutor;
 
     private final RestTemplate restTemplate;
 
     @Value("${gaia.url}")
     private String gaiaUrl;
 
-    public StepRunner(DockerRunner dockerRunner, RestTemplate restTemplate) {
-        this.dockerRunner = dockerRunner;
+    public StepRunner(DockerExecutor dockerExecutor, RestTemplate restTemplate) {
+        this.dockerExecutor = dockerExecutor;
         this.restTemplate = restTemplate;
     }
 
@@ -42,7 +42,7 @@ public class StepRunner {
         // configure a logger to ship logs back to gaia
         StepLogger logger = log -> this.restTemplate.put(gaiaUrl+API_RUNNER_STEPS+stepId+"/logs", log);
 
-        var result = dockerRunner.runJobStepInContainer(image, logger, script, env);
+        var result = dockerExecutor.runJobStepInContainer(image, logger, script, env);
 
         LOG.info("Finished step {} execution with result code {}.", stepId, result);
         LOG.info("Sending result.");

--- a/src/main/java/io/gaia_app/runner/StepRunner.java
+++ b/src/main/java/io/gaia_app/runner/StepRunner.java
@@ -29,9 +29,6 @@ public class StepRunner {
     @Async
     public void runStep(RunnerStep runnerStep) {
         var stepId = runnerStep.getId();
-        var image = runnerStep.getImage();
-        var script = runnerStep.getScript();
-        var env = runnerStep.getEnv();
 
         // tell gaia that the job starts
         this.restTemplate.put(gaiaUrl+ API_RUNNER_STEPS +stepId+"/start", null);
@@ -41,7 +38,7 @@ public class StepRunner {
         // configure a logger to ship logs back to gaia
         StepLogger logger = log -> this.restTemplate.put(gaiaUrl+API_RUNNER_STEPS+stepId+"/logs", log);
 
-        var result = executor.executeJobStep(image, logger, script, env);
+        var result = executor.executeJobStep(runnerStep, logger);
 
         LOG.info("Finished step {} execution with result code {}.", stepId, result);
         LOG.info("Sending result.");

--- a/src/main/java/io/gaia_app/runner/StepRunner.java
+++ b/src/main/java/io/gaia_app/runner/StepRunner.java
@@ -1,6 +1,5 @@
 package io.gaia_app.runner;
 
-import io.gaia_app.runner.docker.DockerExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,15 +14,15 @@ public class StepRunner {
 
     private static final String API_RUNNER_STEPS = "/api/runner/steps/";
 
-    private final DockerExecutor dockerExecutor;
+    private final Executor executor;
 
     private final RestTemplate restTemplate;
 
     @Value("${gaia.url}")
     private String gaiaUrl;
 
-    public StepRunner(DockerExecutor dockerExecutor, RestTemplate restTemplate) {
-        this.dockerExecutor = dockerExecutor;
+    public StepRunner(Executor executor, RestTemplate restTemplate) {
+        this.executor = executor;
         this.restTemplate = restTemplate;
     }
 
@@ -42,7 +41,7 @@ public class StepRunner {
         // configure a logger to ship logs back to gaia
         StepLogger logger = log -> this.restTemplate.put(gaiaUrl+API_RUNNER_STEPS+stepId+"/logs", log);
 
-        var result = dockerExecutor.runJobStepInContainer(image, logger, script, env);
+        var result = executor.executeJobStep(image, logger, script, env);
 
         LOG.info("Finished step {} execution with result code {}.", stepId, result);
         LOG.info("Sending result.");

--- a/src/main/java/io/gaia_app/runner/config/RunnerConfigurationProperties.java
+++ b/src/main/java/io/gaia_app/runner/config/RunnerConfigurationProperties.java
@@ -1,5 +1,6 @@
 package io.gaia_app.runner.config;
 
+import io.gaia_app.runner.ExecutorType;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,12 +14,22 @@ public class RunnerConfigurationProperties {
 
     private int concurrency = 10;
 
+    private ExecutorType executor = ExecutorType.DOCKER;
+
     public int getConcurrency() {
         return concurrency;
     }
 
     public void setConcurrency(int concurrency) {
         this.concurrency = concurrency;
+    }
+
+    public ExecutorType getExecutor() {
+        return executor;
+    }
+
+    public void setExecutor(ExecutorType executor) {
+        this.executor = executor;
     }
 
     @Bean

--- a/src/main/java/io/gaia_app/runner/docker/DockerConfigurationProperties.java
+++ b/src/main/java/io/gaia_app/runner/docker/DockerConfigurationProperties.java
@@ -1,10 +1,12 @@
 package io.gaia_app.runner.docker;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties(prefix="gaia.runner.docker")
+@ConditionalOnProperty(name="gaia.runner.executor", havingValue = "docker")
 public class DockerConfigurationProperties {
 
     private String daemonUrl;

--- a/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
+++ b/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
@@ -8,6 +8,7 @@ import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Volume;
 import io.gaia_app.runner.Executor;
+import io.gaia_app.runner.RunnerStep;
 import io.gaia_app.runner.StepLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +20,6 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -39,7 +39,11 @@ public class DockerExecutor implements Executor {
     }
 
     @Override
-    public int executeJobStep(String image, StepLogger logger, String script, List<String> jobEnv) {
+    public int executeJobStep(RunnerStep step, StepLogger logger) {
+        var image = step.getImage();
+        var script = step.getScript();
+        var jobEnv = step.getEnv();
+
         try {
             var env = new ArrayList<String>();
             env.add("TF_IN_AUTOMATION=true");

--- a/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
+++ b/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
@@ -12,6 +12,7 @@ import io.gaia_app.runner.StepLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.util.concurrent.TimeUnit;
  * Service to run docker container
  */
 @Service
+@ConditionalOnProperty(name="gaia.runner.executor", havingValue = "docker")
 public class DockerExecutor implements Executor {
 
     private static final Logger LOG = LoggerFactory.getLogger(DockerExecutor.class);

--- a/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
+++ b/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
@@ -7,6 +7,7 @@ import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.Volume;
+import io.gaia_app.runner.Executor;
 import io.gaia_app.runner.StepLogger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +25,7 @@ import java.util.concurrent.TimeUnit;
  * Service to run docker container
  */
 @Service
-public class DockerExecutor {
+public class DockerExecutor implements Executor {
 
     private static final Logger LOG = LoggerFactory.getLogger(DockerExecutor.class);
 
@@ -35,7 +36,8 @@ public class DockerExecutor {
         this.dockerClient = dockerClient;
     }
 
-    public int runJobStepInContainer(String image, StepLogger logger, String script, List<String> jobEnv) {
+    @Override
+    public int executeJobStep(String image, StepLogger logger, String script, List<String> jobEnv) {
         try {
             var env = new ArrayList<String>();
             env.add("TF_IN_AUTOMATION=true");

--- a/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
+++ b/src/main/java/io/gaia_app/runner/docker/DockerExecutor.java
@@ -24,14 +24,14 @@ import java.util.concurrent.TimeUnit;
  * Service to run docker container
  */
 @Service
-public class DockerRunner {
+public class DockerExecutor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DockerRunner.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DockerExecutor.class);
 
     private DockerClient dockerClient;
 
     @Autowired
-    public DockerRunner(DockerClient dockerClient) {
+    public DockerExecutor(DockerClient dockerClient) {
         this.dockerClient = dockerClient;
     }
 

--- a/src/main/java/io/gaia_app/runner/docker/DockerJavaClientConfig.java
+++ b/src/main/java/io/gaia_app/runner/docker/DockerJavaClientConfig.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.okhttp.OkDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,6 +16,7 @@ import java.net.URI;
  * Configuration of the docker transport
  */
 @Configuration
+@ConditionalOnProperty(name="gaia.runner.executor", havingValue = "docker")
 public class DockerJavaClientConfig {
 
     private final DockerConfigurationProperties configurationProperties;
@@ -51,6 +53,5 @@ public class DockerJavaClientConfig {
                 .dockerHost(URI.create(configurationProperties.getDaemonUrl()))
                 .build();
     }
-
 
 }

--- a/src/main/java/io/gaia_app/runner/k8s/K8SClientConfig.java
+++ b/src/main/java/io/gaia_app/runner/k8s/K8SClientConfig.java
@@ -1,0 +1,24 @@
+package io.gaia_app.runner.k8s;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.util.Config;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+@ConditionalOnProperty(name = "gaia.runner.executor", havingValue = "k8s")
+public class K8SClientConfig {
+
+    @Bean
+    CoreV1Api coreV1Api() throws IOException {
+        ApiClient client = Config.defaultClient();
+        io.kubernetes.client.openapi.Configuration.setDefaultApiClient(client);
+
+        return new CoreV1Api(client);
+    }
+
+}

--- a/src/main/java/io/gaia_app/runner/k8s/K8SClientConfig.java
+++ b/src/main/java/io/gaia_app/runner/k8s/K8SClientConfig.java
@@ -3,15 +3,24 @@ package io.gaia_app.runner.k8s;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.util.Config;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Configuration
 @ConditionalOnProperty(name = "gaia.runner.executor", havingValue = "k8s")
 public class K8SClientConfig {
+
+    private static final Logger LOGGER = Logger.getLogger("K8SClientConfig");
+
+    private static final Path NAMESPACE_FILE_PATH = Path.of(Config.SERVICEACCOUNT_NAMESPACE_PATH);
 
     @Bean
     CoreV1Api coreV1Api() throws IOException {
@@ -21,4 +30,28 @@ public class K8SClientConfig {
         return new CoreV1Api(client);
     }
 
+    /**
+     * Dynamically configures namespace by reading in-cluster configuration if available
+     */
+    @Autowired
+    void configureNamespace(K8SConfigurationProperties properties) {
+        if (properties.getNamespace() == null) {
+            loadNamespaceFromInCluster(properties, NAMESPACE_FILE_PATH);
+        }
+    }
+
+    void loadNamespaceFromInCluster(K8SConfigurationProperties properties, Path path) {
+        try {
+            // try to load in-cluster namespace
+            LOGGER.log(Level.INFO, "Kubernetes namespace not configured, try to read in-cluster namespace");
+            if (Files.exists(path)) {
+                properties.setNamespace(Files.readString(path));
+                LOGGER.log(Level.INFO, "Loaded namespace {0}", properties.getNamespace());
+            } else {
+                LOGGER.log(Level.SEVERE, "Could not load Kubernetes namespace info. Please configure the `gaia.runner.k8s.namespace` property or `GAIA_RUNNER_K8S_NAMESPACE` env var.");
+            }
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Could not load Kubernetes namespace info. Please configure the `gaia.runner.k8s.namespace` property or `GAIA_RUNNER_K8S_NAMESPACE` env var.");
+        }
+    }
 }

--- a/src/main/java/io/gaia_app/runner/k8s/K8SConfigurationProperties.java
+++ b/src/main/java/io/gaia_app/runner/k8s/K8SConfigurationProperties.java
@@ -1,0 +1,21 @@
+package io.gaia_app.runner.k8s;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix="gaia.runner.k8s")
+@ConditionalOnProperty(name="gaia.runner.executor", havingValue = "k8s")
+class K8SConfigurationProperties {
+
+    private String namespace;
+
+    String getNamespace() {
+        return namespace;
+    }
+
+    void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+}

--- a/src/main/java/io/gaia_app/runner/k8s/K8SExecutor.java
+++ b/src/main/java/io/gaia_app/runner/k8s/K8SExecutor.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gaia_app.runner.Executor;
+import io.gaia_app.runner.RunnerStep;
 import io.gaia_app.runner.StepLogger;
 import io.kubernetes.client.Attach;
 import io.kubernetes.client.PodLogs;
@@ -39,9 +40,13 @@ public class K8SExecutor implements Executor {
     }
 
     @Override
-    public int executeJobStep(String image, StepLogger logger, String script, List<String> jobEnv) {
+    public int executeJobStep(RunnerStep step, StepLogger logger) {
+        var image = step.getImage();
+        var script = step.getScript();
+        var jobEnv = step.getEnv();
+
         var namespace = properties.getNamespace();
-        var podName = "gaia-job-" + UUID.randomUUID();
+        var podName = "gaia-job-" + step.getId();
 
         var env = new ArrayList<String>();
         env.add("TF_IN_AUTOMATION=true");

--- a/src/main/java/io/gaia_app/runner/k8s/K8SExecutor.java
+++ b/src/main/java/io/gaia_app/runner/k8s/K8SExecutor.java
@@ -107,7 +107,7 @@ public class K8SExecutor implements Executor {
             // copy logs (this is done in a sync way, maybe do that in a separate thread?
             try (var stdout = new PodLogs().streamNamespacedPodLog(pod)) {
                 var logsReader = new BufferedReader(new InputStreamReader(stdout));
-                logsReader.lines().forEach(logger::log);
+                logsReader.lines().forEach(it -> logger.log(it+"\n"));
             }
 
         } catch (ApiException e) {

--- a/src/main/java/io/gaia_app/runner/k8s/K8SExecutor.java
+++ b/src/main/java/io/gaia_app/runner/k8s/K8SExecutor.java
@@ -1,0 +1,178 @@
+package io.gaia_app.runner.k8s;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gaia_app.runner.Executor;
+import io.gaia_app.runner.StepLogger;
+import io.kubernetes.client.Attach;
+import io.kubernetes.client.PodLogs;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1EnvVarBuilder;
+import io.kubernetes.client.openapi.models.V1PodBuilder;
+import io.kubernetes.client.util.wait.Wait;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.Duration;
+import java.util.ArrayList;
+
+@Service
+@ConditionalOnProperty(name = "gaia.runner.executor", havingValue = "k8s")
+public class K8SExecutor implements Executor {
+
+    private static final System.Logger LOGGER = System.getLogger("K8SExecutor");
+
+    private CoreV1Api coreV1Api;
+
+    private K8SConfigurationProperties properties;
+
+    @Autowired
+    K8SExecutor(CoreV1Api coreV1Api, K8SConfigurationProperties properties) {
+        this.coreV1Api = coreV1Api;
+        this.properties = properties;
+    }
+
+    @Override
+    public int executeJobStep(String image, StepLogger logger, String script, List<String> jobEnv) {
+        var namespace = properties.getNamespace();
+        var podName = "gaia-job-" + UUID.randomUUID();
+
+        var env = new ArrayList<String>();
+        env.add("TF_IN_AUTOMATION=true");
+        env.addAll(jobEnv);
+
+        // try to create a pod definition
+        var envVars = env.stream()
+                .map(it -> it.split("="))
+                .map(it -> new V1EnvVarBuilder().withName(it[0]).withValue(it[1]).build())
+                .toList();
+
+        var pod = new V1PodBuilder()
+                .withNewMetadata()
+                .withName(podName)
+                .withNamespace(namespace)
+                .endMetadata()
+                .withNewSpec()
+                .withRestartPolicy("Never")
+                .addNewContainer()
+                .withName("terraform")
+                .withCommand("/bin/sh")
+                // open stdin to send commands when attaching to the pod
+                .withStdin(true)
+                .withEnv(envVars)
+                .withImage(image)
+                .endContainer()
+                .endSpec()
+                .build();
+
+        LOGGER.log(System.Logger.Level.INFO, "Creating pod {0}", podName);
+        try {
+            coreV1Api.createNamespacedPod(namespace, pod, null, null, null);
+        } catch (ApiException e) {
+            LOGGER.log(System.Logger.Level.ERROR, "Unable to create Kubernetes pod, Kubernetes API response : {0}", getApiExceptionResponseBodyMessage(e));
+            return 99;
+        }
+
+        LOGGER.log(System.Logger.Level.INFO, "Wait for the pod {0} to be running", podName);
+        Wait.poll(Duration.ofSeconds(1), Duration.ofMinutes(1), () -> {
+            try {
+                var podStatus = coreV1Api.readNamespacedPod(podName, namespace, null).getStatus();
+                return "Running".equals(podStatus.getPhase());
+            } catch (ApiException e) {
+                LOGGER.log(System.Logger.Level.ERROR, "Unable to get status of pod {0} : {1}", podName, getApiExceptionResponseBodyMessage(e));
+                return false;
+            }
+        });
+
+        // attach to the running pod and write the content of the script to the container's stdin
+        LOGGER.log(System.Logger.Level.INFO, "Executing script in pod {0}", podName);
+        try {
+            var attachment = new Attach().attach(pod, true);
+            var stdin = attachment.getStandardInputStream();
+            stdin.write((script + "\n").getBytes());
+            stdin.flush();
+
+            LOGGER.log(System.Logger.Level.INFO, "Getting pod {0} logs", podName);
+            // copy logs (this is done in a sync way, maybe do that in a separate thread?
+            try (var stdout = new PodLogs().streamNamespacedPodLog(pod)) {
+                var logsReader = new BufferedReader(new InputStreamReader(stdout));
+                logsReader.lines().forEach(logger::log);
+            }
+
+        } catch (ApiException e) {
+            LOGGER.log(System.Logger.Level.ERROR, "Unable to send script to Kubernetes pod {0} : {1}", podName, getApiExceptionResponseBodyMessage(e));
+            return destroyPodAndQuit(podName, namespace);
+        } catch (IOException | NullPointerException e) {
+            LOGGER.log(System.Logger.Level.ERROR, "Unable to send script to Kubernetes pod {0} : {1}", podName, e.getMessage());
+            return destroyPodAndQuit(podName, namespace);
+        }
+
+        LOGGER.log(System.Logger.Level.INFO, "Wait for the pod {0} to be completed", podName);
+        Wait.poll(Duration.ofSeconds(1), Duration.ofMinutes(30), () -> {
+            try {
+                var podStatus = coreV1Api.readNamespacedPod(podName, namespace, null).getStatus();
+                return "Succeeded".equals(podStatus.getPhase()) || "Failed".equals(podStatus.getPhase());
+            } catch (ApiException e) {
+                LOGGER.log(System.Logger.Level.ERROR, "Unable to get completion status of pod {0} : {1}", podName, getApiExceptionResponseBodyMessage(e));
+            }
+            return false;
+        });
+
+        int statusCode = -1;
+        LOGGER.log(System.Logger.Level.INFO, "Getting exit code of pod {0}", podName);
+        try {
+            var podStatus = coreV1Api.readNamespacedPod(podName, namespace, null).getStatus();
+            statusCode = podStatus.getContainerStatuses().get(0).getState().getTerminated().getExitCode();
+            LOGGER.log(System.Logger.Level.INFO, "Pod {0} exited with status code {1}", podName, statusCode);
+        } catch (ApiException e) {
+            LOGGER.log(System.Logger.Level.ERROR, "Unable to get exit code of pod {0} : {1}", podName, getApiExceptionResponseBodyMessage(e));
+        }
+
+        LOGGER.log(System.Logger.Level.INFO, "Deleting the pod {0}", podName);
+        try {
+            coreV1Api.deleteNamespacedPod(podName, namespace, null, null, null, null, null, null);
+        } catch (ApiException e) {
+            LOGGER.log(System.Logger.Level.ERROR, "Unable to delete Kubernetes pod, Kubernetes API response : {0}", e.getResponseBody());
+            LOGGER.log(System.Logger.Level.ERROR, "You may need to run `kubectl delete pod {0} -n {0}` to remove the dangling pod", podName, namespace);
+            return -1;
+        }
+
+        return statusCode;
+    }
+
+    record ApiExceptionResponseBody(String message) {
+    }
+
+    private String getApiExceptionResponseBodyMessage(ApiException e) {
+        if (e.getMessage().isBlank()) {
+            var objectMapper = new ObjectMapper();
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            try {
+                var body = objectMapper.readValue(e.getResponseBody(), ApiExceptionResponseBody.class);
+                return body.message;
+            } catch (JsonProcessingException ex) {
+                LOGGER.log(System.Logger.Level.ERROR, "Could not process response message in body: {0}", e.getResponseBody());
+            }
+        }
+        return e.getMessage();
+    }
+
+    /**
+     * Error mgmt method that destroys the given pod
+     * @return
+     */
+    private int destroyPodAndQuit(String podName, String namespace){
+        try {
+            coreV1Api.deleteNamespacedPod(podName, namespace, null, null, null, null, null, null);
+        } catch (ApiException e) {
+            LOGGER.log(System.Logger.Level.ERROR, "Unable to delete Kubernetes pod, Kubernetes API response : {0}", e.getResponseBody());
+        }
+        return 99;
+    }
+}

--- a/src/test/java/io/gaia_app/runner/RunnerIT.java
+++ b/src/test/java/io/gaia_app/runner/RunnerIT.java
@@ -27,6 +27,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
         "gaia.url=https://gaia-app.io",
         "gaia.runner.api.username=gaia-runner",
         "gaia.runner.api.password=gaia-runner-password",
+        "gaia.runner.executor=docker",
 })
 class RunnerIT {
 

--- a/src/test/java/io/gaia_app/runner/StepRunnerTest.java
+++ b/src/test/java/io/gaia_app/runner/StepRunnerTest.java
@@ -1,6 +1,5 @@
 package io.gaia_app.runner;
 
-import io.gaia_app.runner.docker.DockerExecutor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,7 +22,7 @@ class StepRunnerTest {
     private StepRunner stepRunner;
 
     @Mock
-    private DockerExecutor dockerExecutor;
+    private Executor executor;
 
     @Mock
     private RestTemplate restTemplate;
@@ -39,7 +38,7 @@ class StepRunnerTest {
         stepRunner.runStep(runnerStep);
 
         // then
-        verify(dockerExecutor).runJobStepInContainer(eq(image), any(StepLogger.class), eq(script), eq(List.of()));
+        verify(executor).executeJobStep(eq(image), any(StepLogger.class), eq(script), eq(List.of()));
     }
 
     @Test
@@ -51,7 +50,7 @@ class StepRunnerTest {
 
         ReflectionTestUtils.setField(stepRunner, "gaiaUrl", "http://localhost:8080");
 
-        when(dockerExecutor.runJobStepInContainer(eq(image), any(StepLogger.class), eq(script), eq(List.of()))).thenReturn(2);
+        when(executor.executeJobStep(eq(image), any(StepLogger.class), eq(script), eq(List.of()))).thenReturn(2);
 
         // when
         stepRunner.runStep(runnerStep);

--- a/src/test/java/io/gaia_app/runner/StepRunnerTest.java
+++ b/src/test/java/io/gaia_app/runner/StepRunnerTest.java
@@ -38,7 +38,7 @@ class StepRunnerTest {
         stepRunner.runStep(runnerStep);
 
         // then
-        verify(executor).executeJobStep(eq(image), any(StepLogger.class), eq(script), eq(List.of()));
+        verify(executor).executeJobStep(eq(runnerStep), any(StepLogger.class));
     }
 
     @Test
@@ -50,7 +50,7 @@ class StepRunnerTest {
 
         ReflectionTestUtils.setField(stepRunner, "gaiaUrl", "http://localhost:8080");
 
-        when(executor.executeJobStep(eq(image), any(StepLogger.class), eq(script), eq(List.of()))).thenReturn(2);
+        when(executor.executeJobStep(eq(runnerStep), any(StepLogger.class))).thenReturn(2);
 
         // when
         stepRunner.runStep(runnerStep);

--- a/src/test/java/io/gaia_app/runner/StepRunnerTest.java
+++ b/src/test/java/io/gaia_app/runner/StepRunnerTest.java
@@ -1,6 +1,6 @@
 package io.gaia_app.runner;
 
-import io.gaia_app.runner.docker.DockerRunner;
+import io.gaia_app.runner.docker.DockerExecutor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,7 +23,7 @@ class StepRunnerTest {
     private StepRunner stepRunner;
 
     @Mock
-    private DockerRunner dockerRunner;
+    private DockerExecutor dockerExecutor;
 
     @Mock
     private RestTemplate restTemplate;
@@ -39,7 +39,7 @@ class StepRunnerTest {
         stepRunner.runStep(runnerStep);
 
         // then
-        verify(dockerRunner).runJobStepInContainer(eq(image), any(StepLogger.class), eq(script), eq(List.of()));
+        verify(dockerExecutor).runJobStepInContainer(eq(image), any(StepLogger.class), eq(script), eq(List.of()));
     }
 
     @Test
@@ -51,7 +51,7 @@ class StepRunnerTest {
 
         ReflectionTestUtils.setField(stepRunner, "gaiaUrl", "http://localhost:8080");
 
-        when(dockerRunner.runJobStepInContainer(eq(image), any(StepLogger.class), eq(script), eq(List.of()))).thenReturn(2);
+        when(dockerExecutor.runJobStepInContainer(eq(image), any(StepLogger.class), eq(script), eq(List.of()))).thenReturn(2);
 
         // when
         stepRunner.runStep(runnerStep);

--- a/src/test/java/io/gaia_app/runner/config/RunnerConfigurationPropertiesTest.java
+++ b/src/test/java/io/gaia_app/runner/config/RunnerConfigurationPropertiesTest.java
@@ -1,5 +1,6 @@
 package io.gaia_app.runner.config;
 
+import io.gaia_app.runner.ExecutorType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,7 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @TestPropertySource(properties = {
         "gaia.runner.concurrency=1",
         "gaia.runner.api.username=my-gaia-api-username",
-        "gaia.runner.api.password=my-gaia-api-password"
+        "gaia.runner.api.password=my-gaia-api-password",
+        "gaia.runner.executor=docker"
 })
 class RunnerConfigurationPropertiesTest {
 
@@ -30,6 +32,11 @@ class RunnerConfigurationPropertiesTest {
     void testRunnerApiProperties(){
         assertThat(runnerApiProperties.getUsername()).isEqualTo("my-gaia-api-username");
         assertThat(runnerApiProperties.getPassword()).isEqualTo("my-gaia-api-password");
+    }
+
+    @Test
+    void testExecutorProperties(){
+        assertThat(properties.getExecutor()).isEqualTo(ExecutorType.DOCKER);
     }
 
 }

--- a/src/test/java/io/gaia_app/runner/config/RunnerConfigurationPropertiesTest.java
+++ b/src/test/java/io/gaia_app/runner/config/RunnerConfigurationPropertiesTest.java
@@ -7,7 +7,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@SpringBootTest(classes = {RunnerConfiguration.class, RunnerConfigurationProperties.class})
 @TestPropertySource(properties = {
         "gaia.runner.concurrency=1",
         "gaia.runner.api.username=my-gaia-api-username",

--- a/src/test/java/io/gaia_app/runner/docker/DockerConfigurationPropertiesTest.java
+++ b/src/test/java/io/gaia_app/runner/docker/DockerConfigurationPropertiesTest.java
@@ -1,5 +1,7 @@
 package io.gaia_app.runner.docker;
 
+import io.gaia_app.runner.config.RunnerConfiguration;
+import io.gaia_app.runner.config.RunnerConfigurationProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -7,7 +9,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@SpringBootTest(classes = {RunnerConfiguration.class, RunnerConfigurationProperties.class, DockerConfigurationProperties.class})
 @TestPropertySource(properties = {
         "gaia.runner.docker.daemon-url=tcp://localhost:2375",
         "gaia.runner.api.password=random-password",

--- a/src/test/java/io/gaia_app/runner/docker/DockerConfigurationPropertiesTest.java
+++ b/src/test/java/io/gaia_app/runner/docker/DockerConfigurationPropertiesTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(classes = {RunnerConfiguration.class, RunnerConfigurationProperties.class, DockerConfigurationProperties.class})
 @TestPropertySource(properties = {
+        "gaia.runner.executor=docker",
         "gaia.runner.docker.daemon-url=tcp://localhost:2375",
         "gaia.runner.api.password=random-password",
 })

--- a/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
@@ -1,5 +1,6 @@
 package io.gaia_app.runner.docker
 
+import io.gaia_app.runner.RunnerStep
 import io.gaia_app.runner.StepLogger
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -8,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestPropertySource
+import java.util.*
 
 @SpringBootTest(classes = [DockerExecutor::class, DockerJavaClientConfig::class, DockerConfigurationProperties::class])
 @EnableConfigurationProperties
@@ -26,43 +28,48 @@ class DockerExecutorIT {
     @Test
     fun `runContainerForJob() should work with a simple script`() {
         val script = "echo 'Hello World'; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
-        assertEquals(0, dockerExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(0, dockerExecutor.executeJobStep(step, printlnLogger).toLong())
     }
 
     @Test
     fun `runContainerForJob() should stop work with a simple script`() {
         val script = "set -e; echo 'Hello World'; false; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
-        assertEquals(1, dockerExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(1, dockerExecutor.executeJobStep(step, printlnLogger).toLong())
     }
 
     @Test
     fun `runContainerForJob() should return the script exit code`() {
         val script = "exit 5"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
-        assertEquals(5, dockerExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(5, dockerExecutor.executeJobStep(step, printlnLogger).toLong())
     }
 
     @Test
     fun `runContainerForJob() should feed step with container logs`() {
         val script = "echo 'hello world'; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerExecutor.executeJobStep(image, listLogger, script, listOf())
+        dockerExecutor.executeJobStep(step, listLogger)
         assertThat(logs).isEqualTo(listOf("hello world\n"))
     }
 
     @Test
     fun `runContainerForJob() use env of the job`() {
         val script = "echo \$AWS_ACCESS_KEY_ID; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerExecutor.executeJobStep(image, listLogger, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
+        dockerExecutor.executeJobStep(step, listLogger)
 
         assertThat(logs).isEqualTo(listOf("SOME_ACCESS_KEY\n"))
     }
@@ -70,11 +77,12 @@ class DockerExecutorIT {
     @Test
     fun `runContainerForJob() use TF_IN_AUTOMATION env var`() {
         val script = "echo \$TF_IN_AUTOMATION; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerExecutor.executeJobStep(image, listLogger, script, listOf())
+        dockerExecutor.executeJobStep(step, listLogger)
 
         assertThat(logs).isEqualTo(listOf("true\n"));
     }

--- a/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
@@ -9,13 +9,13 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestPropertySource
 
-@SpringBootTest(classes = [DockerRunner::class, DockerJavaClientConfig::class, DockerConfigurationProperties::class])
+@SpringBootTest(classes = [DockerExecutor::class, DockerJavaClientConfig::class, DockerConfigurationProperties::class])
 @EnableConfigurationProperties
 @TestPropertySource(properties = ["gaia.dockerDaemonUrl=unix:///var/run/docker.sock"])
-class DockerRunnerIT {
+class DockerExecutorIT {
 
     @Autowired
-    private lateinit var dockerRunner: DockerRunner
+    private lateinit var dockerExecutor: DockerExecutor
 
     private val image = "hashicorp/terraform:0.13.0"
 
@@ -25,21 +25,21 @@ class DockerRunnerIT {
     fun `runContainerForJob() should work with a simple script`() {
         val script = "echo 'Hello World'; exit 0;"
 
-        assertEquals(0, dockerRunner.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(0, dockerExecutor.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
     }
 
     @Test
     fun `runContainerForJob() should stop work with a simple script`() {
         val script = "set -e; echo 'Hello World'; false; exit 0;"
 
-        assertEquals(1, dockerRunner.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(1, dockerExecutor.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
     }
 
     @Test
     fun `runContainerForJob() should return the script exit code`() {
         val script = "exit 5"
 
-        assertEquals(5, dockerRunner.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(5, dockerExecutor.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
     }
 
     @Test
@@ -49,7 +49,7 @@ class DockerRunnerIT {
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerRunner.runJobStepInContainer(image, listLogger, script, listOf())
+        dockerExecutor.runJobStepInContainer(image, listLogger, script, listOf())
         assertThat(logs).isEqualTo(listOf("hello world\n"))
     }
 
@@ -60,7 +60,7 @@ class DockerRunnerIT {
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerRunner.runJobStepInContainer(image, listLogger, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
+        dockerExecutor.runJobStepInContainer(image, listLogger, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
 
         assertThat(logs).isEqualTo(listOf("SOME_ACCESS_KEY\n"))
     }
@@ -72,7 +72,7 @@ class DockerRunnerIT {
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerRunner.runJobStepInContainer(image, listLogger, script, listOf())
+        dockerExecutor.runJobStepInContainer(image, listLogger, script, listOf())
 
         assertThat(logs).isEqualTo(listOf("true\n"));
     }

--- a/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
@@ -25,21 +25,21 @@ class DockerExecutorIT {
     fun `runContainerForJob() should work with a simple script`() {
         val script = "echo 'Hello World'; exit 0;"
 
-        assertEquals(0, dockerExecutor.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(0, dockerExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
     }
 
     @Test
     fun `runContainerForJob() should stop work with a simple script`() {
         val script = "set -e; echo 'Hello World'; false; exit 0;"
 
-        assertEquals(1, dockerExecutor.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(1, dockerExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
     }
 
     @Test
     fun `runContainerForJob() should return the script exit code`() {
         val script = "exit 5"
 
-        assertEquals(5, dockerExecutor.runJobStepInContainer(image, printlnLogger, script, listOf()).toLong())
+        assertEquals(5, dockerExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
     }
 
     @Test
@@ -49,7 +49,7 @@ class DockerExecutorIT {
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerExecutor.runJobStepInContainer(image, listLogger, script, listOf())
+        dockerExecutor.executeJobStep(image, listLogger, script, listOf())
         assertThat(logs).isEqualTo(listOf("hello world\n"))
     }
 
@@ -60,7 +60,7 @@ class DockerExecutorIT {
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerExecutor.runJobStepInContainer(image, listLogger, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
+        dockerExecutor.executeJobStep(image, listLogger, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
 
         assertThat(logs).isEqualTo(listOf("SOME_ACCESS_KEY\n"))
     }
@@ -72,7 +72,7 @@ class DockerExecutorIT {
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        dockerExecutor.runJobStepInContainer(image, listLogger, script, listOf())
+        dockerExecutor.executeJobStep(image, listLogger, script, listOf())
 
         assertThat(logs).isEqualTo(listOf("true\n"));
     }

--- a/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
@@ -11,7 +11,9 @@ import org.springframework.test.context.TestPropertySource
 
 @SpringBootTest(classes = [DockerExecutor::class, DockerJavaClientConfig::class, DockerConfigurationProperties::class])
 @EnableConfigurationProperties
-@TestPropertySource(properties = ["gaia.dockerDaemonUrl=unix:///var/run/docker.sock"])
+@TestPropertySource(properties = [
+    "gaia.runner.executor=docker",
+])
 class DockerExecutorIT {
 
     @Autowired

--- a/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/docker/DockerExecutorIT.kt
@@ -51,14 +51,14 @@ class DockerExecutorIT {
 
     @Test
     fun `runContainerForJob() should feed step with container logs`() {
-        val script = "echo 'hello world'; exit 0;"
+        val script = "echo 'hello world'; echo 'hello again'; exit 0;"
         val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
         dockerExecutor.executeJobStep(step, listLogger)
-        assertThat(logs).isEqualTo(listOf("hello world\n"))
+        assertThat(logs).isEqualTo(listOf("hello world\nhello again\n"))
     }
 
     @Test

--- a/src/test/java/io/gaia_app/runner/k8s/K8SClientConfigTest.java
+++ b/src/test/java/io/gaia_app/runner/k8s/K8SClientConfigTest.java
@@ -1,0 +1,54 @@
+package io.gaia_app.runner.k8s;
+
+import io.gaia_app.runner.test_utils.LastLogRecordHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class K8SClientConfigTest {
+
+    private LastLogRecordHandler lastLogRecordHandler = new LastLogRecordHandler();
+
+    @BeforeEach
+    void setUp() {
+        var logger = Logger.getLogger("K8SClientConfig");
+        logger.addHandler(lastLogRecordHandler);
+    }
+
+    @Test
+    void testLoadNamespaceFromInCluster() throws IOException {
+        var clientConfig = new K8SClientConfig();
+        var properties = new K8SConfigurationProperties();
+
+        var path = Files.createTempFile("test", "namespace");
+        Files.writeString(path, "gaia-unit-test-namespace");
+
+        clientConfig.loadNamespaceFromInCluster(properties, path);
+
+        assertThat(properties.getNamespace()).isEqualTo("gaia-unit-test-namespace");
+    }
+
+    @Test
+    void testLoadNamespaceFromInCluster_shouldDoNothingIfFileDoesntExists() throws IOException {
+        var clientConfig = new K8SClientConfig();
+
+        var properties = new K8SConfigurationProperties();
+
+        var path = Path.of("non-existing-file-path");
+
+        clientConfig.loadNamespaceFromInCluster(properties, path);
+
+        assertThat(properties.getNamespace()).isNull();
+
+        assertThat(lastLogRecordHandler.getLastLog().getLevel()).isEqualTo(Level.SEVERE);
+        assertThat(lastLogRecordHandler.getLastLog().getMessage()).contains("Could not load Kubernetes namespace info");
+    }
+
+}

--- a/src/test/java/io/gaia_app/runner/k8s/K8SExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/k8s/K8SExecutorIT.kt
@@ -1,0 +1,96 @@
+package io.gaia_app.runner.k8s
+
+import io.gaia_app.runner.StepLogger
+import org.springframework.boot.test.context.SpringBootTest
+import io.gaia_app.runner.k8s.K8SExecutor
+import io.gaia_app.runner.k8s.K8SClientConfig
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.test.context.TestPropertySource
+import org.springframework.beans.factory.annotation.Autowired
+import org.assertj.core.api.AssertionsForClassTypes
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+@SpringBootTest(classes = [K8SExecutor::class, K8SClientConfig::class, K8SConfigurationProperties::class])
+@EnableConfigurationProperties
+@TestPropertySource(properties = [
+    "gaia.runner.executor=k8s",
+    "gaia.runner.k8s.namespace=gaia-runner",
+])
+class K8SExecutorIT {
+
+    @Autowired
+    lateinit var k8SExecutor: K8SExecutor
+
+    private val image = "hashicorp/terraform:0.13.0"
+
+    private val printlnLogger = StepLogger { }
+
+    @Test
+    fun `runContainerForJob() should work with a simple script`() {
+        val script = "echo 'Hello World'; exit 0;"
+
+        Assertions.assertEquals(0, k8SExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+    }
+
+    @Test
+    fun `runContainerForJob() should stop work with a simple script`() {
+        val script = "set -e; echo 'Hello World'; false; exit 0;"
+
+        Assertions.assertEquals(1, k8SExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+    }
+
+    @Test
+    fun `runContainerForJob() should return the script exit code`() {
+        val script = "exit 5"
+
+        Assertions.assertEquals(5, k8SExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+    }
+
+    @Test
+    fun `runContainerForJob() should feed step with container logs`() {
+        val script = "echo 'hello world'; exit 0;"
+
+        val logs = mutableListOf<String>()
+        val listLogger = StepLogger { logs.add(it) }
+
+        k8SExecutor.executeJobStep(image, listLogger, script, listOf())
+        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("hello world"))
+    }
+
+    @Test
+    fun `runContainerForJob() use env of the job`() {
+        val script = "echo \$AWS_ACCESS_KEY_ID; exit 0;"
+
+        val logs = mutableListOf<String>()
+        val listLogger = StepLogger { logs.add(it) }
+
+        k8SExecutor.executeJobStep(image, listLogger, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
+
+        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("SOME_ACCESS_KEY"))
+    }
+
+    @Test
+    fun `runContainerForJob() use TF_IN_AUTOMATION env var`() {
+        val script = "echo \$TF_IN_AUTOMATION; exit 0;"
+
+        val logs = mutableListOf<String>()
+        val listLogger = StepLogger { logs.add(it) }
+
+        k8SExecutor.executeJobStep(image, listLogger, script, listOf())
+
+        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("true"));
+    }
+
+    @Test
+    fun `runContainerForJob() with long task, should work`() {
+        val script = "echo 'sleeping 5 seconds'; sleep 5; echo 'sleeping again 5 seconds'; sleep 5; exit 0;"
+
+        val logs = mutableListOf<String>()
+        val listLogger = StepLogger { logs.add(it) }
+
+        k8SExecutor.executeJobStep(image, listLogger, script, listOf())
+
+        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("sleeping 5 seconds", "sleeping again 5 seconds"));
+    }
+}

--- a/src/test/java/io/gaia_app/runner/k8s/K8SExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/k8s/K8SExecutorIT.kt
@@ -1,5 +1,6 @@
 package io.gaia_app.runner.k8s
 
+import io.gaia_app.runner.RunnerStep
 import io.gaia_app.runner.StepLogger
 import org.springframework.boot.test.context.SpringBootTest
 import io.gaia_app.runner.k8s.K8SExecutor
@@ -10,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.assertj.core.api.AssertionsForClassTypes
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import java.util.*
 
 @SpringBootTest(classes = [K8SExecutor::class, K8SClientConfig::class, K8SConfigurationProperties::class])
 @EnableConfigurationProperties
@@ -20,7 +22,7 @@ import org.junit.jupiter.api.Test
 class K8SExecutorIT {
 
     @Autowired
-    lateinit var k8SExecutor: K8SExecutor
+    lateinit var k8sExecutor: K8SExecutor
 
     private val image = "hashicorp/terraform:0.13.0"
 
@@ -29,43 +31,48 @@ class K8SExecutorIT {
     @Test
     fun `runContainerForJob() should work with a simple script`() {
         val script = "echo 'Hello World'; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
-        Assertions.assertEquals(0, k8SExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+        Assertions.assertEquals(0, k8sExecutor.executeJobStep(step, printlnLogger).toLong())
     }
 
     @Test
     fun `runContainerForJob() should stop work with a simple script`() {
         val script = "set -e; echo 'Hello World'; false; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
-        Assertions.assertEquals(1, k8SExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+        Assertions.assertEquals(1, k8sExecutor.executeJobStep(step, printlnLogger).toLong())
     }
 
     @Test
     fun `runContainerForJob() should return the script exit code`() {
         val script = "exit 5"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
-        Assertions.assertEquals(5, k8SExecutor.executeJobStep(image, printlnLogger, script, listOf()).toLong())
+        Assertions.assertEquals(5, k8sExecutor.executeJobStep(step, printlnLogger).toLong())
     }
 
     @Test
     fun `runContainerForJob() should feed step with container logs`() {
         val script = "echo 'hello world'; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        k8SExecutor.executeJobStep(image, listLogger, script, listOf())
+        k8sExecutor.executeJobStep(step, listLogger)
         org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("hello world"))
     }
 
     @Test
     fun `runContainerForJob() use env of the job`() {
         val script = "echo \$AWS_ACCESS_KEY_ID; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        k8SExecutor.executeJobStep(image, listLogger, script, listOf("AWS_ACCESS_KEY_ID=SOME_ACCESS_KEY"))
+        k8sExecutor.executeJobStep(step, listLogger)
 
         org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("SOME_ACCESS_KEY"))
     }
@@ -73,24 +80,13 @@ class K8SExecutorIT {
     @Test
     fun `runContainerForJob() use TF_IN_AUTOMATION env var`() {
         val script = "echo \$TF_IN_AUTOMATION; exit 0;"
+        val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
-        k8SExecutor.executeJobStep(image, listLogger, script, listOf())
+        k8sExecutor.executeJobStep(step, listLogger)
 
         org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("true"));
-    }
-
-    @Test
-    fun `runContainerForJob() with long task, should work`() {
-        val script = "echo 'sleeping 5 seconds'; sleep 5; echo 'sleeping again 5 seconds'; sleep 5; exit 0;"
-
-        val logs = mutableListOf<String>()
-        val listLogger = StepLogger { logs.add(it) }
-
-        k8SExecutor.executeJobStep(image, listLogger, script, listOf())
-
-        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("sleeping 5 seconds", "sleeping again 5 seconds"));
     }
 }

--- a/src/test/java/io/gaia_app/runner/k8s/K8SExecutorIT.kt
+++ b/src/test/java/io/gaia_app/runner/k8s/K8SExecutorIT.kt
@@ -54,14 +54,14 @@ class K8SExecutorIT {
 
     @Test
     fun `runContainerForJob() should feed step with container logs`() {
-        val script = "echo 'hello world'; exit 0;"
+        val script = "echo 'hello world'; echo 'hello again'; exit 0;"
         val step = RunnerStep(UUID.randomUUID().toString(), image, script, listOf())
 
         val logs = mutableListOf<String>()
         val listLogger = StepLogger { logs.add(it) }
 
         k8sExecutor.executeJobStep(step, listLogger)
-        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("hello world"))
+        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("hello world\n","hello again\n"))
     }
 
     @Test
@@ -74,7 +74,7 @@ class K8SExecutorIT {
 
         k8sExecutor.executeJobStep(step, listLogger)
 
-        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("SOME_ACCESS_KEY"))
+        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("SOME_ACCESS_KEY\n"))
     }
 
     @Test
@@ -87,6 +87,6 @@ class K8SExecutorIT {
 
         k8sExecutor.executeJobStep(step, listLogger)
 
-        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("true"));
+        org.assertj.core.api.Assertions.assertThat(logs).isEqualTo(listOf("true\n"));
     }
 }

--- a/src/test/java/io/gaia_app/runner/k8s/K8SExecutorTest.java
+++ b/src/test/java/io/gaia_app/runner/k8s/K8SExecutorTest.java
@@ -1,0 +1,85 @@
+package io.gaia_app.runner.k8s;
+
+import io.gaia_app.runner.RunnerStep;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.*;
+import okhttp3.Request;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class K8SExecutorTest {
+
+    public static final String POD_NAME = "gaia-job-1234";
+    public static final String NAMESPACE = "test-namespace";
+    @InjectMocks
+    private K8SExecutor executor;
+
+    @Mock
+    private CoreV1Api k8sApi;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private K8SConfigurationProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        when(properties.getNamespace()).thenReturn(NAMESPACE);
+    }
+
+    @Nested
+    class ErrorMgmt {
+
+        @Test
+        void shouldDoNothing_whenPodCantBeCreated() throws ApiException {
+            var k8sException = new ApiException("Could not create pod");
+            doThrow(k8sException).when(k8sApi).createNamespacedPod(anyString(), any(V1Pod.class), isNull(), isNull(), isNull());
+
+            var step = new RunnerStep("1234", "terraform:latest", "echo 'Hello'", List.of());
+            var result = executor.executeJobStep(step, log -> {});
+
+            assertThat(result).isEqualTo(99);
+
+            verify(k8sApi).createNamespacedPod(anyString(), any(V1Pod.class), isNull(), isNull(), isNull());
+
+            verifyNoMoreInteractions(k8sApi);
+        }
+
+        @Test
+        void shouldDestroyPod_whenPodCanBeCreated_butScriptCantBeExecuted() throws ApiException {
+            var runningPod = new V1Pod();
+            runningPod.setStatus(new V1PodStatus());
+            runningPod.getStatus().setPhase("Running");
+            when(k8sApi.readNamespacedPod(POD_NAME, NAMESPACE, null)).thenReturn(runningPod);
+
+            var step = new RunnerStep("1234", "terraform:latest", "echo 'Hello'", List.of());
+            var result = executor.executeJobStep(step, log -> {});
+
+            assertThat(result).isEqualTo(99);
+
+            verify(k8sApi).createNamespacedPod(anyString(), any(V1Pod.class), isNull(), isNull(), isNull());
+            verify(k8sApi).deleteNamespacedPod(anyString(), anyString(), isNull(), isNull(), isNull(), isNull(), isNull(), isNull());
+            verifyNoMoreInteractions(k8sApi);
+        }
+
+    }
+
+}

--- a/src/test/java/io/gaia_app/runner/test_utils/LastLogRecordHandler.java
+++ b/src/test/java/io/gaia_app/runner/test_utils/LastLogRecordHandler.java
@@ -1,0 +1,24 @@
+package io.gaia_app.runner.test_utils;
+
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+public class LastLogRecordHandler extends Handler {
+
+    private LogRecord lastLog;
+
+    @Override
+    public void publish(LogRecord record) {
+        this.lastLog = record;
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() throws SecurityException {}
+
+    public LogRecord getLastLog() {
+        return lastLog;
+    }
+}


### PR DESCRIPTION
This PR introduces a new kubernetes executor.

I extracted a `Executor` interface out of the `DockerRunner`, then I implemented a Kubernetes Executor.

This now allows Gaia Runner to run jobs in-cluster, in the same namespace that its deployed in, without having to depend on a Docker daemon.